### PR TITLE
Text-path-handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ htmlcov
 __pycache__
 
 output/
+
+# MacOS
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from svg_to_usd.version import Version
 
 setuptools.setup(name='svg_to_usd',
-                 version=Version('0.1.16').number,
+                 version=Version('0.1.17').number,
                  description="Convert SVG vectors to Pixar's Universal Scene Description",
                  long_description=open('README.md').read().strip(),
                  packages=setuptools.find_packages(),

--- a/svg_to_usd/convert.py
+++ b/svg_to_usd/convert.py
@@ -35,10 +35,6 @@ def convert(svg_path, usd_stage, svg_str=None):
         common.parent_map = {c: p for p in root.getiterator() for c in p} 
     else:
         common.parent_map = {c: p for p in tree.iter() for c in p}
-    print("common parent_map", common.parent_map)
-    print("root", root)
-    print("root attrib", root.attrib)
-    print("usd stage", usd_stage)
 
     # Setup utils
 

--- a/svg_to_usd/convert.py
+++ b/svg_to_usd/convert.py
@@ -17,13 +17,28 @@ def convert_new(svg_path, usd_path):
     return stage
 
 
-def convert(svg_path, usd_stage):
+def convert(svg_path, usd_stage, svg_str=None):
     import xml.etree.ElementTree as ET
+    root = ""
+    if svg_str:
+        root = ET.fromstring(svg_str)
+    else:
+        tree = ET.parse(svg_path)
+        root = tree.getroot()
 
-    tree = ET.parse(svg_path)
-    root = tree.getroot()
+    i = 0
+    for el in root.iter():
+        el.set("tree_id", i)
+        i +=1
 
-    common.parent_map = {c: p for p in tree.iter() for c in p}
+    if svg_str:
+        common.parent_map = {c: p for p in root.getiterator() for c in p} 
+    else:
+        common.parent_map = {c: p for p in tree.iter() for c in p}
+    print("common parent_map", common.parent_map)
+    print("root", root)
+    print("root attrib", root.attrib)
+    print("usd stage", usd_stage)
 
     # Setup utils
 

--- a/svg_to_usd/converter/common.py
+++ b/svg_to_usd/converter/common.py
@@ -60,7 +60,7 @@ def handle_element(usd_stage, svg_element, parent_prim=None):
 
     prim_path = "{}".format(svg_id)
     # Adding a text prefix because the return value could be a number.
-    if svg_element.tag.rpartition('}')[-1] == "text":
+    if svg_element.tag.rpartition('}')[-1] == "text" and 'id' not in svg_element.attrib:
         prim_path = "text_{}".format(prim_path)
 
     if parent_prim:
@@ -119,6 +119,5 @@ def preprocess_svg_root(stage, root, parent_prim=None):
 
 def handle_svg_root(stage, root, parent_prim=None):
     for elem in root:
-        print("elem", elem)
         usd_prim = handle_element(stage, elem, parent_prim)
         handle_svg_root(stage, elem, usd_prim)

--- a/svg_to_usd/converter/font.py
+++ b/svg_to_usd/converter/font.py
@@ -1,0 +1,317 @@
+""" Defines the Font class and a utility method to parse free-form font
+specification strings into Font instances. 
+This is a modification of the Kiva Font class file:
+https://github.com/enthought/enable/blob/main/kiva/fonttools/font.py
+"""
+import copy
+import warnings
+
+from matplotlib import font_manager as fm
+font_manager = fm.FontManager()
+
+import os
+
+# -----------------------------------------------------------------------------
+# Font Constants
+# -----------------------------------------------------------------------------
+dirname = os.path.dirname(__file__)
+GLYPH_BLOB_PATH = os.path.join(dirname, "fonts")
+
+NORMAL = 0
+BOLD = 1
+ITALIC = 2
+BOLD_ITALIC = 3
+
+# convenience sets for styles
+bold_styles = {BOLD, BOLD_ITALIC}
+italic_styles = {ITALIC, BOLD_ITALIC}
+
+# Font families, as defined by the Windows API, and their CSS equivalents
+DEFAULT = 0
+SWISS = 1  # Sans-serif
+ROMAN = 2  # Serif
+MODERN = 3  # Monospace
+DECORATIVE = 4  # Fantasy
+SCRIPT = 5  # Cursive
+TELETYPE = 6
+
+# Font weight constants
+WEIGHT_THIN = 100
+WEIGHT_EXTRALIGHT = 200
+WEIGHT_LIGHT = 300
+WEIGHT_NORMAL = 400
+WEIGHT_MEDIUM = 500
+WEIGHT_SEMIBOLD = 600
+WEIGHT_BOLD = 700
+WEIGHT_EXTRABOLD = 800
+WEIGHT_HEAVY = 900
+WEIGHT_EXTRAHEAVY = 1000
+
+# Various maps used by str_to_font
+font_families = {
+    "default": DEFAULT,
+    "decorative": DECORATIVE,
+    "roman": ROMAN,
+    "script": SCRIPT,
+    "swiss": SWISS,
+    "modern": MODERN,
+}
+font_styles = {"italic": ITALIC}
+font_weights = {"bold": WEIGHT_BOLD}
+font_noise = {"pt", "point", "family"}
+
+
+FAMILIES = {
+    'default': DEFAULT,
+    'cursive': SCRIPT,
+    'decorative': DECORATIVE,
+    'fantasy': DECORATIVE,
+    'modern': MODERN,
+    'monospace': MODERN,
+    'roman': ROMAN,
+    'sans-serif': SWISS,
+    'script': SCRIPT,
+    'serif': ROMAN,
+    'swiss': SWISS,
+    'teletype': TELETYPE,
+    'typewriter': TELETYPE,
+}
+WEIGHTS = {
+    'thin': WEIGHT_THIN,
+    'extralight': WEIGHT_EXTRALIGHT,
+    'ultralight': WEIGHT_EXTRALIGHT,
+    'light': WEIGHT_LIGHT,
+    'regular': WEIGHT_NORMAL,
+    'book': WEIGHT_NORMAL,
+    'normal': WEIGHT_NORMAL,
+    'roman': WEIGHT_NORMAL,
+    'medium': WEIGHT_MEDIUM,
+    'semibold': WEIGHT_SEMIBOLD,
+    'demibold': WEIGHT_SEMIBOLD,
+    'bold': WEIGHT_BOLD,
+    'extrabold': WEIGHT_EXTRABOLD,
+    'ultrabold': WEIGHT_EXTRABOLD,
+    'black': WEIGHT_HEAVY,
+    'heavy': WEIGHT_HEAVY,
+    'extraheavy': WEIGHT_EXTRAHEAVY
+}
+STYLES = {
+    'italic': ITALIC,
+    'oblique': ITALIC,
+}
+DECORATIONS = {'underline'}
+NOISE = {'pt', 'point', 'px', 'family'}
+
+
+def str_to_font(fontspec):
+    """
+    Converts a string specification of a font into a Font instance.
+    string specifications are of the form: "modern 12", "9 roman italic",
+    and so on.
+    """
+    point_size = 10
+    family = DEFAULT
+    style = NORMAL
+    weight = WEIGHT_NORMAL
+    underline = 0
+    facename = []
+    for word in fontspec.split():
+        lword = word.lower()
+        if lword in FAMILIES:
+            family = FAMILIES[lword]
+        elif lword in STYLES:
+            style = STYLES[lword]
+        elif lword in WEIGHTS:
+            weight = WEIGHTS[lword]
+        elif lword == "underline":
+            underline = 1
+        elif lword not in font_noise:
+            try:
+                point_size = int(lword)
+            except Exception:
+                facename.append(word)
+    return Font(
+        size=point_size,
+        family=family,
+        weight=weight,
+        style=style,
+        underline=underline,
+        face_name=" ".join(facename),
+    )
+
+
+class Font(object):
+    """ Font class for device independent font specification.
+
+        It is primarily based on wxPython, but looks to be similar to
+        the needs of Mac OS X, etc.
+
+        The family defaults to SWISS so that font rotation will work
+        correctly under wxPython.
+    """
+
+    # Maps the constants for font families to names to use when searching for
+    # fonts.
+    familymap = {
+        DEFAULT: "serif",
+        SWISS: "sans-serif",
+        ROMAN: "serif",
+        MODERN: "sans-serif",
+        DECORATIVE: "fantasy",
+        SCRIPT: "script",
+        TELETYPE: "monospace",
+    }
+
+    def __init__(self, face_name="", size=12, family=SWISS,
+                 weight=WEIGHT_NORMAL, style=NORMAL, underline=0,
+                 encoding=DEFAULT):
+        if not isinstance(face_name, str):
+            raise RuntimeError(
+                f"Expected face name to be a str, got {face_name!r}")
+        if not isinstance(size, int):
+            raise RuntimeError(
+                f"Expected size to be an int, got {size!r}")
+        if not isinstance(family, int):
+            raise RuntimeError(
+                f"Expected family to be an int, got {family!r}")
+        if not isinstance(weight, int):
+            raise RuntimeError(
+                f"Expected weight to be an int, got {weight!r}")
+        if not isinstance(style, int):
+            raise RuntimeError(
+                f"Expected style to be an int, got {style!r}")
+        if not isinstance(underline, int):
+            raise RuntimeError(
+                f"Expected underline to be a int, got {underline!r}")
+        if not isinstance(encoding, int):
+            raise RuntimeError(
+                f"Expected encoding to be an int, got {encoding!r}")
+
+        self.face_name = face_name
+        self.size = size
+        self.family = family
+        self.weight = weight
+        self.style = style
+        self.underline = underline
+        self.encoding = encoding
+
+        # correct the style and weight if needed
+        self.weight = self._get_weight()
+        self.style = style & ~BOLD
+
+    def findfont(self):
+        """ Returns the file name and face index of the font that most closely
+        matches our font properties.
+        
+        """
+        query = self._make_font_query()
+
+        return font_manager.findfont(query)
+
+    def findfontname(self):
+        """ Returns the name of the font that most closely matches our font
+        properties.
+
+        """
+        query = self._make_font_query()
+
+        return query.get_name()
+
+    def is_bold(self):
+        """Is the font considered bold or not?
+
+        This is a convenience method for backends which don't fully support
+        font weights.  We consider a font to be bold if its weight is more
+        than medium.
+        """
+        weight = self._get_weight()
+        return (weight > WEIGHT_MEDIUM)
+
+    def get_glyph_blob(self):
+        font_path = self.findfont()
+
+        basename, ext = os.path.splitext(os.path.basename(font_path))
+        glyph_blob_file = os.path.join(GLYPH_BLOB_PATH, "{}.json".format(basename))
+        if os.path.exists(glyph_blob_file):
+            return glyph_blob_file
+
+        print("No glyph blob found")
+
+
+    def _make_font_query(self):
+        """ Returns a FontQuery object that encapsulates our font properties.
+        """
+        weight = self._get_weight()
+
+        if self.style in italic_styles:
+            style = "italic"
+        else:
+            style = "normal"
+
+        query = fm.FontProperties(
+            family=self.familymap[self.family],
+            style=style,
+            weight=weight,
+            size=self.size,
+        )
+        if self.face_name != "":
+            query.set_name(self.face_name)
+        return query
+
+    def _get_weight(self):
+        """Get a corrected weight value from the font.
+
+        """
+        if self.weight == BOLD:
+            warnings.warn(
+                "Use WEIGHT_BOLD instead of BOLD for Font.weight",
+                DeprecationWarning
+            )
+            return WEIGHT_BOLD
+        elif self.style in bold_styles:
+            warnings.warn(
+                "Set Font.weight to WEIGHT_BOLD instead of Font.style to "
+                "BOLD or BOLD_STYLE",
+                DeprecationWarning
+            )
+            # if weight is default, and style is bold, report as bold
+            if self.weight == WEIGHT_NORMAL:
+                return WEIGHT_BOLD
+
+        return self.weight
+
+    def _get_name(self):
+        return self.face_name
+
+    def _set_name(self, val):
+        self.face_name = val
+
+    name = property(_get_name, _set_name)
+
+    def copy(self):
+        """ Returns a copy of the font object.
+        """
+        return copy.deepcopy(self)
+
+    def __eq__(self, other):
+        try:
+            return (self.family == other.family
+                    and self.face_name == other.face_name
+                    and self.size == other.size
+                    and self.weight == other.weight
+                    and self.style == other.style
+                    and self.underline == other.underline
+                    and self.encoding == other.encoding)
+        except AttributeError:
+            pass
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return (
+            f"Font(face_name='{self.face_name}', size={self.size}, "
+            f"family={self.family}, weight={self.weight}, style={self.style}, "
+            f"underline={self.underline}, encoding={self.encoding})"
+        )

--- a/svg_to_usd/converter/geometry/text.py
+++ b/svg_to_usd/converter/geometry/text.py
@@ -1,28 +1,15 @@
 from pxr import Usd, UsdGeom, Tf, Sdf, Gf
 import logging
-import subprocess
 from .. import utils
+from .. import font
 from pprint import pprint
-
-import os, sys
 
 from fontTools import ttLib
 from fontTools.pens.basePen import BasePen
 from fontTools.pens.transformPen import TransformPen
 
-from opentypesvg.__version__ import version as __version__
-from opentypesvg.utils import (
-    create_folder,
-    create_nested_folder,
-    final_message,
-    get_gnames_to_save_in_nested_folder,
-    get_output_folder_path,
-    split_comma_sequence,
-    validate_font_paths,
-    write_file,
-)
-from pathlib import Path
 from svgpath2mpl import parse_path
+
 
 class SVGPen(BasePen):
 
@@ -74,224 +61,100 @@ class SVGPen(BasePen):
         return [int(flt) if (flt).is_integer() else flt for flt in tup]
 
 
-# OS Font paths
-try:
-    _HOME = Path.home()
-except Exception:  # Exceptions thrown by home() are not specified...
-    _HOME = Path(os.devnull)  # Just an arbitrary path with no children.
-MSFolders = \
-    r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
-MSFontDirectories = [
-    r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts',
-    r'SOFTWARE\Microsoft\Windows\CurrentVersion\Fonts']
-MSUserFontDirectories = [
-    str(_HOME / 'AppData/Local/Microsoft/Windows/Fonts'),
-    str(_HOME / 'AppData/Roaming/Microsoft/Windows/Fonts'),
-]
-X11FontDirectories = [
-    # an old standard installation point
-    "/usr/X11R6/lib/X11/fonts/TTF/",
-    "/usr/X11/lib/X11/fonts",
-    # here is the new standard location for fonts
-    "/usr/share/fonts/",
-    # documented as a good place to install new fonts
-    "/usr/local/share/fonts/",
-    # common application, not really useful
-    "/usr/lib/openoffice/share/fonts/truetype/",
-    # user fonts
-    str((Path(os.environ.get('XDG_DATA_HOME') or _HOME / ".local/share"))
-        / "fonts"),
-    str(_HOME / ".fonts"),
-]
-OSXFontDirectories = [
-    "/Library/Fonts/",
-    "/Network/Library/Fonts/",
-    "/System/Library/Fonts/",
-    # fonts installed via MacPorts
-    "/opt/local/share/fonts",
-    # user fonts
-    str(_HOME / "Library/Fonts"),
-]
+def get_font_properties(element):
+    """
+    Get the base text attributes that all elements will use.
+    The format and types returned are compatible with the Font Class
 
-def get_fontext_synonyms(fontext):
+    Parameters
+    ----------
+    element : xml_element
+        The svg element to be parsed.
+
+    Returns
+    -------
+    properties : dict
+        Font properties suitable for use in creating a Font instance.
     """
-    Return a list of file extensions extensions that are synonyms for
-    the given file extension *fileext*.
-    """
+
+    svg_font_family = "Arial" # TODO: Configurable fallback font
+    svg_font_weight = None 
+    svg_font_style = 0 
+    svg_font_size = 144
+
+    if 'font-family' in element.attrib:
+        svg_font_family = element.attrib['font-family']
+
+    if 'font-weight' in element.attrib:
+        svg_font_weight = element.attrib['font-weight'].lower()
+        try:
+            svg_font_weight = font.WEIGHTS[svg_font_weight]
+        except:
+            svg_font_weight = int(svg_font_weight) 
+
+    if 'font-size' in element.attrib:
+        svg_font_size = int(element.attrib['font-size'])
+
+    if 'font-style' in element.attrib:
+        if element.attrib['font-style'] == 'italic':
+            svg_font_style = 2
+
+    if svg_font_weight == None:
+        svg_font_weight = 400
+
     return {
-        'afm': ['afm'],
-        'otf': ['otf', 'ttc', 'ttf'],
-        'ttc': ['otf', 'ttc', 'ttf'],
-        'ttf': ['otf', 'ttc', 'ttf'],
-    }[fontext]
+        "family": svg_font_family,
+        "size": svg_font_size,
+        "weight": svg_font_weight,
+        "style": svg_font_style
+    }
 
-def _get_win32_installed_fonts():
-    """List the font paths known to the Windows registry."""
-    import winreg
-    items = set()
-    # Search and resolve fonts listed in the registry.
-    for domain, base_dirs in [
-            (winreg.HKEY_LOCAL_MACHINE, [win32FontDirectory()]),  # System.
-            (winreg.HKEY_CURRENT_USER, MSUserFontDirectories),  # User.
-    ]:
-        for base_dir in base_dirs:
-            for reg_path in MSFontDirectories:
-                try:
-                    with winreg.OpenKey(domain, reg_path) as local:
-                        for j in range(winreg.QueryInfoKey(local)[1]):
-                            # value may contain the filename of the font or its
-                            # absolute path.
-                            key, value, tp = winreg.EnumValue(local, j)
-                            if not isinstance(value, str):
-                                continue
-                            try:
-                                # If value contains already an absolute path,
-                                # then it is not changed further.
-                                path = Path(base_dir, value).resolve()
-                            except RuntimeError:
-                                # Don't fail with invalid entries.
-                                continue
-                            items.add(path)
-                except (OSError, MemoryError):
-                    continue
-    return items
+def create_usd_text_mesh(word, glyphSet, cmap, usd_mesh, units_per_em, font_size):
+    svg_d = ""
+    usd_points = []
+    usd_fvi = []
+    usd_fvc = []
+    _charXOffset = 0
 
+    for c in word:
 
-def win32FontDirectory():
-    r"""
-    Return the user-specified font directory for Win32.  This is
-    looked up from the registry key ::
-      \\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\Fonts
-    If the key is not found, ``%WINDIR%\Fonts`` will be returned.
-    """
-    import winreg
-    try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, MSFolders) as user:
-            return winreg.QueryValueEx(user, 'Fonts')[0]
-    except OSError:
-        return os.path.join(os.environ['WINDIR'], 'Fonts')
+        try:
+            glyph = glyphSet[cmap[ord(c)]]
+        except:
+            glyph = glyphSet['.notdef']
+            continue
 
-def _get_fontconfig_fonts():
-    """Cache and list the font paths known to ``fc-list``."""
-    try:
-        if b'--format' not in subprocess.check_output(['fc-list', '--help']):
-            _log.warning(  # fontconfig 2.7 implemented --format.
-                'Matplotlib needs fontconfig>=2.7 to query system fonts.')
-            return []
-        out = subprocess.check_output(['fc-list', '--format=%{file}\\n'])
-    except (OSError, subprocess.CalledProcessError):
-        return []
-    return [Path(os.fsdecode(fname)) for fname in out.split(b'\n')]
+        if c == ' ':
+            _charXOffset += glyph.width
+            continue
 
+        pen = SVGPen(glyphSet)
+        tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
 
-def list_fonts(directory, extensions):
-    """
-    Return a list of all fonts matching any of the extensions, found
-    recursively under the directory.
-    """
-    extensions = ["." + ext for ext in extensions]
-    return [os.path.join(dirpath, filename)
-            # os.walk ignores access errors, unlike Path.glob.
-            for dirpath, _, filenames in os.walk(directory)
-            for filename in filenames
-            if Path(filename).suffix.lower() in extensions]
+        glyph.draw(tpen)
+        svg_path = parse_path(pen.d)
 
+        d = pen.d
 
-def findSystemFonts(fontpaths=None, fontext='ttf'):
-    """
-    Search for fonts in the specified font paths.  If no paths are
-    given, will use a standard set of system paths, as well as the
-    list of fonts tracked by fontconfig if fontconfig is installed and
-    available.  A list of TrueType fonts are returned by default with
-    AFM fonts as an option.
-    """
-    fontfiles = set()
-    fontexts = get_fontext_synonyms(fontext)
+        # Skip glyphs with no contours
+        if not len(d):
+            continue
 
-    if fontpaths is None:
-        if sys.platform == 'win32':
-            installed_fonts = _get_win32_installed_fonts()
-            fontpaths = MSUserFontDirectories + [win32FontDirectory()]
-        else:
-            installed_fonts = _get_fontconfig_fonts()
-            if sys.platform == 'darwin':
-                fontpaths = [*X11FontDirectories, *OSXFontDirectories]
-            else:
-                fontpaths = X11FontDirectories
-        fontfiles.update(str(path) for path in installed_fonts
-                         if path.suffix.lower()[1:] in fontexts)
+        svg_d = d
 
-    elif isinstance(fontpaths, str):
-        fontpaths = [fontpaths]
+        svg_path = parse_path(svg_d)
 
-    for path in fontpaths:
-        fontfiles.update(map(os.path.abspath, list_fonts(path, fontexts)))
+        usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
+            svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em)*font_size)
 
-    # print("fontfiles", fontfiles)
-    ft_files = []
-    font_dict = {}
-    for fname in fontfiles:
-        if os.path.exists(fname):
-            # print("fname", fname)
-            if fname.endswith("ttc"):
-                fonts = ttLib.TTCollection(fname)
-                for font in fonts:
-                    name = font['name']
-                    family_name = name.getBestFamilyName()
-                    style = name.getBestSubFamilyName()
-                    if fname not in font_dict.keys():
-                       font_dict[fname] = [{"family": family_name, "style": style}]
-                    else:
-                    # This is going to break because it expects one family name and style per path.
-                        font_dict[fname].append({"family": family_name, "style": style})
-            else:        
-                font = ttLib.TTFont(fname)
-                name = font['name']
-                family_name = name.getBestFamilyName()
-                style = name.getBestSubFamilyName()
-                font_dict[fname] = [{"family": family_name, "style": style}]
-                dir = os.path.dirname(fname)
-                basename = os.path.basename(fname).lower()
-                ft_files.append(os.path.join(dir, basename))
+        _charXOffset += glyph.width
 
-    
-    # ft_files = [os.path.basename(fname).lower() for fname in fontfiles if os.path.exists(fname)] 
-    # pprint(ft_files)
-    # print("font_dict", font_dict) 
-    # return [fname for fname in fontfiles if os.path.exists(fname)]
-    # return ft_files
-    return font_dict
+    usd_mesh.CreatePointsAttr().Set(usd_points)
+    usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
+    usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
 
-#What would be a better way to create this dictionary once and reuse it?
-font_dict = findSystemFonts()
+    return usd_mesh
 
-font_weights = {
-    100: "Hairline",
-    200: "Thin",
-    300: "Light",
-    400: "Normal",
-    500: "Medium",
-    600: "Semibold",
-    700: "Bold",
-    800: "Extrabold",
-    900: "Black"
-}
-
-
-def find_font_file(family, style):
-
-    # font_dict = findSystemFonts(fontpaths="/Library/Fonts")
-    # font_dict = findSystemFonts()
-    matches = []
-    for key in font_dict:
-        for i in range(len(font_dict[key])):
-        # print("key", key)
-        # print("family", family)
-        # print("style", style)
-            if font_dict[key][i]["family"] == family and font_dict[key][i]["style"] == style:
-                matches.append(key)
-
-    return matches
 
 def convert(usd_stage, prim_path, svg_text, fallback_font, type):
     if type == "geometry":
@@ -302,33 +165,24 @@ def convert(usd_stage, prim_path, svg_text, fallback_font, type):
 def convert_as_schema(usd_stage, prim_path, svg_text, fallback_font):
     logging.debug("Creating text: schema")
     
-    # svg_word = svg_text.text
-    # if not svg_word.strip():
-    #     # Hack to get first span
-    #     svg_word = svg_text[0].text
+    font_props = get_font_properties(svg_text)
 
-    # if not svg_word:
-    #     return
-
-    svg_font_family = "Arial" # TODO: Configurable fallback font
-    if 'font-family' in svg_text.attrib:
-        svg_font_family = svg_text.attrib['font-family']
-
-    # TODO: This is probably buggy
-    svg_font_weight = ""
-    if 'font-weight' in svg_text.attrib:
-        svg_font_weight = svg_text.attrib['font-weight'].capitalize()
-        svg_font_family += "-" + svg_font_weight
-
-    svg_font_size = 144
-    if 'font-size' in svg_text.attrib:
-        svg_font_size = float(svg_text.attrib['font-size']) 
+    #initialise the generalised Font Class instance
+    svg_font = font.Font(face_name=font_props["family"], size=font_props["size"], weight=font_props["weight"], style=font_props["style"])
+    
+    # TODO: The creation of usd_font feels like it could be moved into the font class
+    temp_weight = " {}".format([k for k, v in font.WEIGHTS.items() if svg_font.weight == v][0].title())
+    if temp_weight == " Regular":
+        temp_weight = ""
+    temp_style = ""
+    if svg_font.style == 2:
+        temp_style = " Italic"
+    usd_font = "{}{}{}".format(svg_font.findfontname(), temp_weight, temp_style)
 
     text_group = usd_stage.DefinePrim(prim_path, "Xform")
     logging.debug(svg_text)
     for tspan in svg_text:
-        # tspan
-        svg_word = tspan.text
+        svg_word = " ".join(tspan.text.splitlines())
 
         # Sometimes tspans can be empty, we skip these
         if not svg_word:
@@ -336,14 +190,16 @@ def convert_as_schema(usd_stage, prim_path, svg_text, fallback_font):
 
         prim = usd_stage.DefinePrim(text_group.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}".format(svg_word))), "Preliminary_Text")
         prim.CreateAttribute("content", Sdf.ValueTypeNames.String).Set(svg_word)
-        prim.CreateAttribute("font", Sdf.ValueTypeNames.StringArray).Set([svg_font_family])
+        prim.CreateAttribute("font", Sdf.ValueTypeNames.StringArray).Set([usd_font])
         prim.CreateAttribute("depth", Sdf.ValueTypeNames.Float).Set(0.0)
         prim.CreateAttribute("horizontalAlignment", Sdf.ValueTypeNames.String).Set("left")
         prim.CreateAttribute("verticalAlignment", Sdf.ValueTypeNames.String).Set("middle")
-        prim.CreateAttribute("pointSize", Sdf.ValueTypeNames.Float).Set(svg_font_size)
+        prim.CreateAttribute("pointSize", Sdf.ValueTypeNames.Float).Set(svg_font.size)
         prim.CreateAttribute("wrapMode", Sdf.ValueTypeNames.String).Set("flowing")
         prim.CreateAttribute("width", Sdf.ValueTypeNames.Float).Set(10)
         prim.CreateAttribute("height", Sdf.ValueTypeNames.Float).Set(10)
+        if 'id' in svg_text.attrib:
+            prim.CreateAttribute("id", Sdf.ValueTypeNames.String).Set(svg_text.attrib['id'])
 
 
         try:
@@ -355,261 +211,90 @@ def convert_as_schema(usd_stage, prim_path, svg_text, fallback_font):
         except:
             svg_y = 0.0
 
-        # TODO: These should be xform ops
-        prim.CreateAttribute("x", Sdf.ValueTypeNames.Float).Set(svg_x)
-        prim.CreateAttribute("y", Sdf.ValueTypeNames.Float).Set(svg_y)
+        xform = UsdGeom.Xform(prim)
+        
+        xform.AddTransformOp(opSuffix="xy").Set(
+            Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(svg_x, 0, svg_y)))
 
     return text_group
 
 def convert_as_geo(usd_stage, prim_path, svg_text, fallback_font):
+
+    # Might be a better place to put this. Needed for setting extents later.
+    bboxCache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), includedPurposes=[UsdGeom.Tokens.default_])
+
     logging.debug("Creating text")
     text_root = None
 
+    svg_fill = None
+    font_path = ""
+    gSet = None
+    cmap = None
+    t = None
+    units_per_em = 2048
+
+    if 'fill' in svg_text.attrib:
+        svg_fill = svg_text.attrib['fill']
+
+    #Get the base font properties
+    font_props = get_font_properties(svg_text)
+    #Create a generalised Font instance
+    svg_font = font.Font(face_name=font_props["family"], size=font_props["size"], weight=font_props["weight"], style=font_props["style"])
+    
+    temp_weights = " {}".format([" "+k for k, v in font.WEIGHTS.items() if svg_font.weight == v])
+    if svg_font.weight == 400:
+        temp_weights = [""]
+    temp_style = ""
+    if svg_font.style == 2:
+        temp_style = " italic"
+    ft_styles = []
+    for weight in temp_weights:
+        style = "{}{}".format(weight, temp_style) 
+        if style.strip() == "":
+            style = "regular"
+        style = style.strip()
+        ft_styles.append(style)
+
+    if "/" in font_props["family"] or "\\" in font_props["family"]:
+        print("font_path", font_props["family"])
+        font_path = font_props["family"]
+    else:
+        print("Font:", svg_font)
+        font_path = svg_font.findfont()
+
+    try:
+        ftfont = None
+        if font_path.endswith("ttc"):
+                fonts = ttLib.TTCollection(font_path)
+                for fnt in fonts:
+                    name = fnt['name']
+                    family = name.getBestFamilyName()
+                    style = name.getBestSubFamilyName()
+                    if family == svg_font.name and style.lower() in ft_styles:
+                        ftfont = fnt 
+        else:
+            ftfont = ttLib.TTFont(font_path)
+        cmap = ftfont['cmap']
+        t = cmap.getBestCmap()
+        units_per_em = ftfont['head'].unitsPerEm
+
+        gSet = ftfont.getGlyphSet()
+        ftfont.close()
+
+    except ttLib.TTLibError:
+        logging.error(f"ERROR: {fallback_font} cannot be processed.")
+        return 1
+    
     #Check if the text element has any children. Most likely <tspan> elements.
-    if(len(list(svg_text)) > 0):
+    if(len(list(svg_text)) > 1):
         #Create an xform to hold the tspan elements.
-        # text_root = usd_stage.DefinePrim(prim_path, "Xform")
         text_root = UsdGeom.Xform.Define(usd_stage, prim_path)
 
-        #Get the root text attributes that all the tspan will use.
-        svg_font_family = "Arial"
-        svg_font_weight = None 
-        svg_font_style = None
-        svg_font_size = 16
-        font_path = fallback_font
+        svg_fill = None
+        font_path = ""
         gSet = None
         cmap = None
         t = None
-        units_per_em = 2048
-
-
-        if 'font-family' in svg_text.attrib:
-            svg_font_family = svg_text.attrib['font-family']
-            if 'font-style' in svg_text.attrib:
-                svg_font_style = svg_text.attrib['font-style'].title()
-            if 'font-weight' in svg_text.attrib:
-                svg_font_weight = svg_text.attrib['font-weight']
-
-            print("family: {}, style: {}, weight: {}".format(svg_font_family, svg_font_style, svg_font_weight))
-            
-            if svg_font_weight == None and svg_font_style == None:
-                svg_font_style = "Regular"
-            elif svg_font_weight and svg_font_style == None:
-                try:
-                    svg_font_style = font_weights[int(svg_font_weight)]
-                except:
-                    svg_font_style = svg_font_weight.title()
-            elif svg_font_weight and svg_font_style:
-                # print("both weight and style")
-                try:
-                    svg_font_style = "{} {}".format(font_weights[int(svg_font_weight)], svg_font_style)
-                    # print("style:", svg_font_style)
-                except:
-                    svg_font_style = "{} {}".format(svg_font_weight.title(), svg_font_style)
-                    # print("style:", svg_font_style) 
-
-            if "/" in svg_font_family or "\\" in svg_font_family:
-                print("font_path", svg_font_family)
-                font_path = svg_font_family
-            else:
-                # print("svg font family, weight, style", svg_font_family, svg_font_style)
-                m = find_font_file(svg_font_family, svg_font_style)
-                print("m", m)
-                font_path = m[-1]
-
-            try:
-                font = None
-                if font_path.endswith("ttc"):
-                        fonts = ttLib.TTCollection(font_path)
-                        for fnt in fonts:
-                            name = fnt['name']
-                            family = name.getBestFamilyName()
-                            style = name.getBestSubFamilyName()
-                            # print("family - style: {}-{}".format(family, style))
-                            if family == svg_font_family and style == svg_font_style:
-                                font = fnt 
-                else:
-                    font = ttLib.TTFont(font_path)
-                cmap = font['cmap']
-                # t = cmap.getcmap(3, 1).cmap
-                t = cmap.getBestCmap()
-                units_per_em = font['head'].unitsPerEm
-
-                gSet = font.getGlyphSet()
-                font.close()
-
-            except ttLib.TTLibError:
-                logging.error(f"ERROR: {fallback_font} cannot be processed.")
-                return 1
-
-            if 'font-size' in svg_text.attrib:
-                svg_font_size = (float(svg_text.attrib['font-size'].replace('px', '')))
-
-            align = 0
-            if 'text-anchor' in svg_text.attrib:
-                svg_text_anchor = svg_text.attrib['text-anchor']
-                if svg_text_anchor == "middle":
-                    align = -2
-                elif svg_text_anchor == "end":
-                    align = -4
-
-            # Ideally we'd want to add these transforms to the root but the transform order
-            # is incorrect. We need translate, scale, but this gives us scale, translate.
-
-            # text_root.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
-            #     Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
-            # text_root.AddTransformOp(opSuffix="align").Set(
-            #     Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
-
-            for tspan in svg_text:
-                svg_word = tspan.text
-
-                # Sometimes tspans can be empty. We skip these
-                if not svg_word:
-                    continue
-
-                usd_mesh = UsdGeom.Mesh.Define(usd_stage, text_root.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}_{}".format(svg_word, tspan.attrib['tree_id']))))
-                # print("usd_mesh BEFORE handle attr:", usd_mesh)
-                # usd_mesh = usd_stage.DefinePrim(text_root.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}".format(svg_word))), "Mesh")
-                utils.handle_geom_attrs(tspan, usd_mesh) 
-
-                usd_mesh.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
-                    Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
-                usd_mesh.AddTransformOp(opSuffix="align").Set(
-                    Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
-
-                svg_d = ""
-
-                usd_points = []
-                usd_fvi = []
-                usd_fvc = []
-                _charXOffset = 0
-
-                for c in svg_word:
-
-                    try:
-                        glyph = gSet[t[ord(c)]]
-                    except:
-                        glyph = gSet['.notdef']
-                        continue
-
-                    if c == ' ':
-                        _charXOffset += glyph.width
-                        continue
-
-                    pen = SVGPen(gSet)
-                    tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
-
-                    glyph.draw(tpen)
-                    svg_path = parse_path(pen.d)
-
-                    d = pen.d
-
-                    # Skip glyphs with no contours
-                    if not len(d):
-                        continue
-
-                    svg_d = d
-
-                    svg_path = parse_path(svg_d)
-
-                    usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
-                        svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em))
-
-                    _charXOffset += glyph.width
-
-                usd_mesh.CreatePointsAttr().Set(usd_points)
-                usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
-                usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
-    
-    #Do this if the text element doesn't have any children elements.
-    else:
-
-        text_root = UsdGeom.Mesh.Define(usd_stage, prim_path)
-
-        utils.handle_geom_attrs(svg_text, text_root)
-
-        svg_word = svg_text.text
-        
-        if not svg_word:
-            # Hack to get first span
-            svg_word = svg_text[0].text
-
-            # print(svg_word)
-
-        if not svg_word:
-            return
-        svg_font_size = 16
-
-        gSet = None
-
-        cmap = None
-        t = None
-        units_per_em = 2048
-
-        font_path = fallback_font
-
-        if 'font-family' in svg_text.attrib:
-            svg_font_family = svg_text.attrib['font-family']
-            svg_font_style = None 
-            svg_font_weight = None
-            if 'font-style' in svg_text.attrib:
-                svg_font_style = svg_text.attrib['font-style'].title()
-            if 'font-weight' in svg_text.attrib:
-                svg_font_weight = svg_text.attrib['font-weight']
-
-            print("family: {}, style: {}, weight: {}".format(svg_font_family, svg_font_style, svg_font_weight))
-            
-            if svg_font_weight == None and svg_font_style == None:
-                svg_font_style = "Regular"
-            elif svg_font_weight and svg_font_style == None:
-                try:
-                    svg_font_style = font_weights[int(svg_font_weight)]
-                except:
-                    svg_font_style = svg_font_weight.title()
-            elif svg_font_weight and svg_font_style:
-                try:
-                    svg_font_style = "{} {}".format(font_weights[int(svg_font_weight)], svg_font_style)
-                except:
-                    svg_font_style = "{} {}".format(svg_font_weight.title(), svg_font_style)
-
-            if "/" in svg_font_family or "\\" in svg_font_family:
-                print("font_path", svg_font_family)
-                font_path = svg_font_family
-            else:
-                m = find_font_file(svg_font_family, svg_font_style)
-                print("m", m)
-                font_path = m[-1]
-
-        # font_path = "/Library/Fonts/Yahoo Sans-Regular.otf"
-
-        try:
-            font = None
-            if font_path.endswith("ttc"):
-                    fonts = ttLib.TTCollection(font_path)
-                    for fnt in fonts:
-                        name = fnt['name']
-                        family = name.getBestFamilyName()
-                        style = name.getBestSubFamilyName()
-                        # print("family - style: {}-{}".format(family, style))
-                        if family == svg_font_family and style == svg_font_style:
-                            font = fnt 
-            else:
-                font = ttLib.TTFont(font_path)
-            cmap = font['cmap']
-            # t = cmap.getcmap(3, 1).cmap
-            t = cmap.getBestCmap()
-            units_per_em = font['head'].unitsPerEm
-
-            gSet = font.getGlyphSet()
-            font.close()
-
-        except ttLib.TTLibError:
-            logging.error(f"ERROR: {fallback_font} cannot be processed.")
-            return 1
-
-        if 'font-size' in svg_text.attrib:
-            svg_font_size = (float(svg_text.attrib['font-size'].replace('px', '')))
 
         align = 0
         if 'text-anchor' in svg_text.attrib:
@@ -619,54 +304,58 @@ def convert_as_geo(usd_stage, prim_path, svg_text, fallback_font):
             elif svg_text_anchor == "end":
                 align = -4
 
-        usd_mesh.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
-            Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
-        usd_mesh.AddTransformOp(opSuffix="align").Set(
+        for tspan in svg_text:
+            svg_word = tspan.text
+
+            # Sometimes tspans can be empty. We skip these
+            if not svg_word:
+                continue
+
+            usd_mesh = UsdGeom.Mesh.Define(usd_stage, text_root.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}_{}".format(svg_word, tspan.attrib['tree_id']))))
+            # add parent fill colour if none exists
+            if 'fill' not in tspan.attrib:
+                tspan.attrib['fill'] = svg_fill
+
+            utils.handle_geom_attrs(tspan, usd_mesh) 
+
+            usd_mesh.AddTransformOp(opSuffix="align").Set(
+                Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
+
+            create_usd_text_mesh(svg_word, gSet, t, usd_mesh, units_per_em, svg_font.size)
+
+            utils.set_extent(usd_mesh.GetPrim(), bboxCache)
+    
+    #Do this if the text element doesn't have any children elements.
+    else:
+        text_root = UsdGeom.Mesh.Define(usd_stage, prim_path)
+
+        utils.handle_geom_attrs(svg_text, text_root)
+
+        svg_word = svg_text.text
+
+        if not svg_word:
+            # Hack to get first span
+            svg_word = svg_text[0].text
+        
+        if not svg_word:
+            return
+
+        font_path = fallback_font
+
+        align = 0
+        if 'text-anchor' in svg_text.attrib:
+            svg_text_anchor = svg_text.attrib['text-anchor']
+            if svg_text_anchor == "middle":
+                align = -2
+            elif svg_text_anchor == "end":
+                align = -4
+
+        text_root.AddTransformOp(opSuffix="align").Set(
             Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
 
-        svg_d = ""
+        create_usd_text_mesh(svg_word, gSet, t, text_root, units_per_em, svg_font.size)
 
-        usd_points = []
-        usd_fvi = []
-        usd_fvc = []
-        _charXOffset = 0
-
-        for c in svg_word:
-
-            try:
-                glyph = gSet[t[ord(c)]]
-            except:
-                glyph = gSet['.notdef']
-                continue
-
-            if c == ' ':
-                _charXOffset += glyph.width
-                continue
-
-            pen = SVGPen(gSet)
-            tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
-
-            glyph.draw(tpen)
-            svg_path = parse_path(pen.d)
-
-            d = pen.d
-
-            # Skip glyphs with no contours
-            if not len(d):
-                continue
-
-            svg_d = d
-
-            svg_path = parse_path(svg_d)
-
-            usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
-                svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em))
-
-            _charXOffset += glyph.width
-
-        usd_mesh.CreatePointsAttr().Set(usd_points)
-        usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
-        usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
+        utils.set_extent(text_root.GetPrim(), bboxCache)
 
     return text_root
 

--- a/svg_to_usd/converter/geometry/text.py
+++ b/svg_to_usd/converter/geometry/text.py
@@ -279,7 +279,6 @@ font_weights = {
 
 
 def find_font_file(family, style):
-    print("query", family, style)
 
     # font_dict = findSystemFonts(fontpaths="/Library/Fonts")
     # font_dict = findSystemFonts()
@@ -291,8 +290,7 @@ def find_font_file(family, style):
         # print("style", style)
             if font_dict[key][i]["family"] == family and font_dict[key][i]["style"] == style:
                 matches.append(key)
-    # matches = list(filter(lambda path: family.lower() in os.path.basename(path), findSystemFonts()))
-    print("matches", matches)
+
     return matches
 
 def convert(usd_stage, prim_path, svg_text, fallback_font, type):
@@ -365,157 +363,310 @@ def convert_as_schema(usd_stage, prim_path, svg_text, fallback_font):
 
 def convert_as_geo(usd_stage, prim_path, svg_text, fallback_font):
     logging.debug("Creating text")
+    text_root = None
 
-    usd_mesh = UsdGeom.Mesh.Define(usd_stage, prim_path)
+    #Check if the text element has any children. Most likely <tspan> elements.
+    if(len(list(svg_text)) > 0):
+        #Create an xform to hold the tspan elements.
+        # text_root = usd_stage.DefinePrim(prim_path, "Xform")
+        text_root = UsdGeom.Xform.Define(usd_stage, prim_path)
 
-    utils.handle_geom_attrs(svg_text, usd_mesh)
+        #Get the root text attributes that all the tspan will use.
+        svg_font_family = "Arial"
+        svg_font_weight = None 
+        svg_font_style = None
+        svg_font_size = 16
+        font_path = fallback_font
+        gSet = None
+        cmap = None
+        t = None
+        units_per_em = 2048
 
-    svg_word = svg_text.text
-    print("svg_word", svg_word)
+
+        if 'font-family' in svg_text.attrib:
+            svg_font_family = svg_text.attrib['font-family']
+            if 'font-style' in svg_text.attrib:
+                svg_font_style = svg_text.attrib['font-style'].title()
+            if 'font-weight' in svg_text.attrib:
+                svg_font_weight = svg_text.attrib['font-weight']
+
+            print("family: {}, style: {}, weight: {}".format(svg_font_family, svg_font_style, svg_font_weight))
+            
+            if svg_font_weight == None and svg_font_style == None:
+                svg_font_style = "Regular"
+            elif svg_font_weight and svg_font_style == None:
+                try:
+                    svg_font_style = font_weights[int(svg_font_weight)]
+                except:
+                    svg_font_style = svg_font_weight.title()
+            elif svg_font_weight and svg_font_style:
+                # print("both weight and style")
+                try:
+                    svg_font_style = "{} {}".format(font_weights[int(svg_font_weight)], svg_font_style)
+                    # print("style:", svg_font_style)
+                except:
+                    svg_font_style = "{} {}".format(svg_font_weight.title(), svg_font_style)
+                    # print("style:", svg_font_style) 
+
+            if "/" in svg_font_family or "\\" in svg_font_family:
+                print("font_path", svg_font_family)
+                font_path = svg_font_family
+            else:
+                # print("svg font family, weight, style", svg_font_family, svg_font_style)
+                m = find_font_file(svg_font_family, svg_font_style)
+                print("m", m)
+                font_path = m[-1]
+
+            try:
+                font = None
+                if font_path.endswith("ttc"):
+                        fonts = ttLib.TTCollection(font_path)
+                        for fnt in fonts:
+                            name = fnt['name']
+                            family = name.getBestFamilyName()
+                            style = name.getBestSubFamilyName()
+                            # print("family - style: {}-{}".format(family, style))
+                            if family == svg_font_family and style == svg_font_style:
+                                font = fnt 
+                else:
+                    font = ttLib.TTFont(font_path)
+                cmap = font['cmap']
+                # t = cmap.getcmap(3, 1).cmap
+                t = cmap.getBestCmap()
+                units_per_em = font['head'].unitsPerEm
+
+                gSet = font.getGlyphSet()
+                font.close()
+
+            except ttLib.TTLibError:
+                logging.error(f"ERROR: {fallback_font} cannot be processed.")
+                return 1
+
+            if 'font-size' in svg_text.attrib:
+                svg_font_size = (float(svg_text.attrib['font-size'].replace('px', '')))
+
+            align = 0
+            if 'text-anchor' in svg_text.attrib:
+                svg_text_anchor = svg_text.attrib['text-anchor']
+                if svg_text_anchor == "middle":
+                    align = -2
+                elif svg_text_anchor == "end":
+                    align = -4
+
+            # Ideally we'd want to add these transforms to the root but the transform order
+            # is incorrect. We need translate, scale, but this gives us scale, translate.
+
+            # text_root.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
+            #     Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
+            # text_root.AddTransformOp(opSuffix="align").Set(
+            #     Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
+
+            for tspan in svg_text:
+                svg_word = tspan.text
+
+                # Sometimes tspans can be empty. We skip these
+                if not svg_word:
+                    continue
+
+                usd_mesh = UsdGeom.Mesh.Define(usd_stage, text_root.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}_{}".format(svg_word, tspan.attrib['tree_id']))))
+                # print("usd_mesh BEFORE handle attr:", usd_mesh)
+                # usd_mesh = usd_stage.DefinePrim(text_root.GetPath().AppendChild(Tf.MakeValidIdentifier("tspan_{}".format(svg_word))), "Mesh")
+                utils.handle_geom_attrs(tspan, usd_mesh) 
+
+                usd_mesh.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
+                    Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
+                usd_mesh.AddTransformOp(opSuffix="align").Set(
+                    Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
+
+                svg_d = ""
+
+                usd_points = []
+                usd_fvi = []
+                usd_fvc = []
+                _charXOffset = 0
+
+                for c in svg_word:
+
+                    try:
+                        glyph = gSet[t[ord(c)]]
+                    except:
+                        glyph = gSet['.notdef']
+                        continue
+
+                    if c == ' ':
+                        _charXOffset += glyph.width
+                        continue
+
+                    pen = SVGPen(gSet)
+                    tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+
+                    glyph.draw(tpen)
+                    svg_path = parse_path(pen.d)
+
+                    d = pen.d
+
+                    # Skip glyphs with no contours
+                    if not len(d):
+                        continue
+
+                    svg_d = d
+
+                    svg_path = parse_path(svg_d)
+
+                    usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
+                        svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em))
+
+                    _charXOffset += glyph.width
+
+                usd_mesh.CreatePointsAttr().Set(usd_points)
+                usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
+                usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
     
-    if not svg_word:
-        # Hack to get first span
-        svg_word = svg_text[0].text
-        for child in svg_text:
-            print("child element", child)
-            print("child text", child.text)
+    #Do this if the text element doesn't have any children elements.
+    else:
 
-        # print(svg_word)
+        text_root = UsdGeom.Mesh.Define(usd_stage, prim_path)
 
-    if not svg_word:
-        return
-    svg_font_size = 16
+        utils.handle_geom_attrs(svg_text, text_root)
 
-    gSet = None
-
-    cmap = None
-    t = None
-    units_per_em = 2048
-
-    font_path = fallback_font
-
-    if 'font-family' in svg_text.attrib:
-        svg_font_family = svg_text.attrib['font-family']
-        svg_font_style = None 
-        svg_font_weight = None
-        if 'font-style' in svg_text.attrib:
-            svg_font_style = svg_text.attrib['font-style'].title()
-        if 'font-weight' in svg_text.attrib:
-            svg_font_weight = svg_text.attrib['font-weight']
-
-        print("family: {}, style: {}, weight: {}".format(svg_font_family, svg_font_style, svg_font_weight))
+        svg_word = svg_text.text
         
-        if svg_font_weight == None and svg_font_style == None:
-            svg_font_style = "Regular"
-        elif svg_font_weight and svg_font_style == None:
-            try:
-                svg_font_style = font_weights[int(svg_font_weight)]
-            except:
-                svg_font_style = svg_font_weight.title()
-        elif svg_font_weight and svg_font_style:
-            print("both weight and style")
-            try:
-                svg_font_style = "{} {}".format(font_weights[int(svg_font_weight)], svg_font_style)
-                print("style:", svg_font_style)
-            except:
-                svg_font_style = "{} {}".format(svg_font_weight.title(), svg_font_style)
-                print("style:", svg_font_style) 
+        if not svg_word:
+            # Hack to get first span
+            svg_word = svg_text[0].text
 
-        if "/" in svg_font_family or "\\" in svg_font_family:
-            print("font_path", svg_font_family)
-            font_path = svg_font_family
-        else:
-            print("svg font family, weight, style", svg_font_family, svg_font_style)
-            m = find_font_file(svg_font_family, svg_font_style)
-            print("m", m)
-            font_path = m[-1]
+            # print(svg_word)
 
-    # font_path = "/Library/Fonts/Yahoo Sans-Regular.otf"
+        if not svg_word:
+            return
+        svg_font_size = 16
 
-    try:
-        font = None
-        if font_path.endswith("ttc"):
-                fonts = ttLib.TTCollection(font_path)
-                for fnt in fonts:
-                    name = fnt['name']
-                    family = name.getBestFamilyName()
-                    style = name.getBestSubFamilyName()
-                    # print("family - style: {}-{}".format(family, style))
-                    if family == svg_font_family and style == svg_font_style:
-                        font = fnt 
-        else:
-            font = ttLib.TTFont(font_path)
-        cmap = font['cmap']
-        # t = cmap.getcmap(3, 1).cmap
-        t = cmap.getBestCmap()
-        units_per_em = font['head'].unitsPerEm
+        gSet = None
 
-        gSet = font.getGlyphSet()
-        font.close()
+        cmap = None
+        t = None
+        units_per_em = 2048
 
-    except ttLib.TTLibError:
-        logging.error(f"ERROR: {fallback_font} cannot be processed.")
-        return 1
+        font_path = fallback_font
 
-    if 'font-size' in svg_text.attrib:
-        svg_font_size = (float(svg_text.attrib['font-size'].replace('px', '')))
+        if 'font-family' in svg_text.attrib:
+            svg_font_family = svg_text.attrib['font-family']
+            svg_font_style = None 
+            svg_font_weight = None
+            if 'font-style' in svg_text.attrib:
+                svg_font_style = svg_text.attrib['font-style'].title()
+            if 'font-weight' in svg_text.attrib:
+                svg_font_weight = svg_text.attrib['font-weight']
 
-    align = 0
-    if 'text-anchor' in svg_text.attrib:
-        svg_text_anchor = svg_text.attrib['text-anchor']
-        if svg_text_anchor == "middle":
-            align = -2
-        elif svg_text_anchor == "end":
-            align = -4
+            print("family: {}, style: {}, weight: {}".format(svg_font_family, svg_font_style, svg_font_weight))
+            
+            if svg_font_weight == None and svg_font_style == None:
+                svg_font_style = "Regular"
+            elif svg_font_weight and svg_font_style == None:
+                try:
+                    svg_font_style = font_weights[int(svg_font_weight)]
+                except:
+                    svg_font_style = svg_font_weight.title()
+            elif svg_font_weight and svg_font_style:
+                try:
+                    svg_font_style = "{} {}".format(font_weights[int(svg_font_weight)], svg_font_style)
+                except:
+                    svg_font_style = "{} {}".format(svg_font_weight.title(), svg_font_style)
 
-    usd_mesh.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
-        Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
-    usd_mesh.AddTransformOp(opSuffix="align").Set(
-        Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
+            if "/" in svg_font_family or "\\" in svg_font_family:
+                print("font_path", svg_font_family)
+                font_path = svg_font_family
+            else:
+                m = find_font_file(svg_font_family, svg_font_style)
+                print("m", m)
+                font_path = m[-1]
 
-    svg_d = ""
-
-    usd_points = []
-    usd_fvi = []
-    usd_fvc = []
-    _charXOffset = 0
-
-    for c in svg_word:
+        # font_path = "/Library/Fonts/Yahoo Sans-Regular.otf"
 
         try:
-            glyph = gSet[t[ord(c)]]
-        except:
-            glyph = gSet['.notdef']
-            continue
+            font = None
+            if font_path.endswith("ttc"):
+                    fonts = ttLib.TTCollection(font_path)
+                    for fnt in fonts:
+                        name = fnt['name']
+                        family = name.getBestFamilyName()
+                        style = name.getBestSubFamilyName()
+                        # print("family - style: {}-{}".format(family, style))
+                        if family == svg_font_family and style == svg_font_style:
+                            font = fnt 
+            else:
+                font = ttLib.TTFont(font_path)
+            cmap = font['cmap']
+            # t = cmap.getcmap(3, 1).cmap
+            t = cmap.getBestCmap()
+            units_per_em = font['head'].unitsPerEm
 
-        if c == ' ':
+            gSet = font.getGlyphSet()
+            font.close()
+
+        except ttLib.TTLibError:
+            logging.error(f"ERROR: {fallback_font} cannot be processed.")
+            return 1
+
+        if 'font-size' in svg_text.attrib:
+            svg_font_size = (float(svg_text.attrib['font-size'].replace('px', '')))
+
+        align = 0
+        if 'text-anchor' in svg_text.attrib:
+            svg_text_anchor = svg_text.attrib['text-anchor']
+            if svg_text_anchor == "middle":
+                align = -2
+            elif svg_text_anchor == "end":
+                align = -4
+
+        usd_mesh.AddTransformOp(opSuffix="text").Set(Gf.Matrix4d(1.0).SetScale(
+            Gf.Vec3d(svg_font_size, svg_font_size, svg_font_size)))
+        usd_mesh.AddTransformOp(opSuffix="align").Set(
+            Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(align, 0, 0)))
+
+        svg_d = ""
+
+        usd_points = []
+        usd_fvi = []
+        usd_fvc = []
+        _charXOffset = 0
+
+        for c in svg_word:
+
+            try:
+                glyph = gSet[t[ord(c)]]
+            except:
+                glyph = gSet['.notdef']
+                continue
+
+            if c == ' ':
+                _charXOffset += glyph.width
+                continue
+
+            pen = SVGPen(gSet)
+            tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+
+            glyph.draw(tpen)
+            svg_path = parse_path(pen.d)
+
+            d = pen.d
+
+            # Skip glyphs with no contours
+            if not len(d):
+                continue
+
+            svg_d = d
+
+            svg_path = parse_path(svg_d)
+
+            usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
+                svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em))
+
             _charXOffset += glyph.width
-            continue
 
-        pen = SVGPen(gSet)
-        tpen = TransformPen(pen, (1.0, 0.0, 0.0, -1.0, 0.0, 0.0))
+        usd_mesh.CreatePointsAttr().Set(usd_points)
+        usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
+        usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
 
-        glyph.draw(tpen)
-        svg_path = parse_path(pen.d)
-
-        d = pen.d
-
-        # Skip glyphs with no contours
-        if not len(d):
-            continue
-
-        svg_d = d
-
-        svg_path = parse_path(svg_d)
-
-        usd_points, usd_fvi, usd_fvc = utils.path_to_mesh(
-            svg_path, usd_points, usd_fvi, usd_fvc, _charXOffset, 0, 1.0/(units_per_em))
-
-        _charXOffset += glyph.width
-
-    usd_mesh.CreatePointsAttr().Set(usd_points)
-    usd_mesh.CreateFaceVertexIndicesAttr().Set(usd_fvi)
-    usd_mesh.CreateFaceVertexCountsAttr().Set(usd_fvc)
-
-    return usd_mesh
+    return text_root
 

--- a/svg_to_usd/converter/utils.py
+++ b/svg_to_usd/converter/utils.py
@@ -8,18 +8,17 @@ from . import common
 ELLIPSIS_RES = 32
 UP_AXIS = "Y"
 
-ID_COUNT = 0
+# ID_COUNT = 0 
 
 
 def get_id(svg_element):
-    global ID_COUNT
+    # global ID_COUNT
 
     if 'id' in svg_element.attrib:
         return Tf.MakeValidIdentifier(svg_element.attrib['id'])
-
-    ID_COUNT += 1
-
-    return "ob_{}".format(ID_COUNT)
+    else:
+        # ID_COUNT += 1
+        return "ob_{}".format(svg_element.attrib['tree_id'])
 
 
 def default_normal():
@@ -389,11 +388,20 @@ def handle_geom_attrs(svg_element, usd_mesh):
     try:
         svg_x = float(svg_element.attrib['x'])
     except:
-        svg_x = 0.0
+        try:
+            svg_x = float(svg_element[0].attrib['x'])
+        except:
+            svg_x = 0.0
     try:
         svg_y = float(svg_element.attrib['y'])
     except:
-        svg_y = 0.0
+        try:
+            svg_y = float(svg_element[0].attrib['y'])
+        except:
+            svg_y = 0.0
+
+    usd_mesh.AddTransformOp(opSuffix="xy").Set(
+        Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(svg_x, 0, svg_y)))
 
     # - Colors
 
@@ -463,7 +471,7 @@ def handle_geom_attrs(svg_element, usd_mesh):
     disallow_list = ["fill", "style", "x", "y",
                      "transform", "d", "x1", "x2", "y1", "y2", "points"]
     # These probably arent useful
-    disallow_list += ["clip_path", "clip_path_id"]
+    disallow_list += ["clip_path", "clip_path_id", "tree_id"]
 
     for _attr in svg_element.attrib:
         if _attr in disallow_list:

--- a/svg_to_usd/converter/utils.py
+++ b/svg_to_usd/converter/utils.py
@@ -485,3 +485,13 @@ def handle_geom_attrs(svg_element, usd_mesh):
                 _attr), _type, UsdGeom.Tokens.constant).Set(_val)
 
     return usd_mesh
+
+def set_extent(prim, bboxCache):
+    # Get bbox
+    bb = bboxCache.ComputeWorldBound(prim)
+    
+    # Get min and max vecs
+    minr = bb.GetRange().GetMin() 
+    maxr = bb.GetRange().GetMax()
+    
+    prim.GetAttribute('extent').Set([minr, maxr]) 

--- a/svg_to_usd/converter/utils.py
+++ b/svg_to_usd/converter/utils.py
@@ -384,24 +384,25 @@ def handle_geom_attrs(svg_element, usd_mesh):
     handle_xform_attrs(svg_element, usd_mesh)
 
     # - X, Y
-    # TODO: Implement
-    try:
-        svg_x = float(svg_element.attrib['x'])
-    except:
+    if svg_element.tag.rpartition('}')[-1] == "text" or svg_element.tag.rpartition('}')[-1] == "tspan":
+        # TODO: Implement
         try:
-            svg_x = float(svg_element[0].attrib['x'])
+            svg_x = float(svg_element.attrib['x'])
         except:
-            svg_x = 0.0
-    try:
-        svg_y = float(svg_element.attrib['y'])
-    except:
+            try:
+                svg_x = float(svg_element[0].attrib['x'])
+            except:
+                svg_x = 0.0
         try:
-            svg_y = float(svg_element[0].attrib['y'])
+            svg_y = float(svg_element.attrib['y'])
         except:
-            svg_y = 0.0
+            try:
+                svg_y = float(svg_element[0].attrib['y'])
+            except:
+                svg_y = 0.0
 
-    usd_mesh.AddTransformOp(opSuffix="xy").Set(
-        Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(svg_x, 0, svg_y)))
+        usd_mesh.AddTransformOp(opSuffix="xy").Set(
+            Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(svg_x, 0, svg_y)))
 
     # - Colors
 


### PR DESCRIPTION
The convert function now accepts an optional svg tree string.
Each element is assigned an id based on the tree. This is used for elements that have no id and is more consistent than the previous setup.
Exposed the text_type option allowing the user to generate the schema or geometry for text.
The text converter should now handle most font paths, weights and styles.
If the text_type is geometry and a text element has multiple tspans, a mesh is created for each tspan. Previously, only the first tspan would generate a mesh.

